### PR TITLE
Move job execution out of Backstage.Job

### DIFF
--- a/lib/backstage/consumer.ex
+++ b/lib/backstage/consumer.ex
@@ -98,6 +98,8 @@ defmodule Backstage.Consumer do
   end
 
   defp start_task(job) do
-    Task.Supervisor.async_nolink(Backstage.TaskSupervisor, Backstage.Job, :run, [job])
+    {mod, fun, args} = :erlang.binary_to_term(job.payload)
+
+    Task.Supervisor.async_nolink(Backstage.TaskSupervisor, mod, fun, args)
   end
 end

--- a/lib/backstage/job.ex
+++ b/lib/backstage/job.ex
@@ -48,13 +48,6 @@ defmodule Backstage.Job do
     timestamps usec: true
   end
 
-  # TODO: think about whether we want to enforce jobs having to return :ok to indicate they're successful
-  # The alternative is to assume the job is successful if it returns anything except {:error, reason}
-  def run(%__MODULE__{} = job) do
-    {mod, fun, args} = :erlang.binary_to_term(job.payload)
-    apply(mod, fun, args)
-  end
-
   # TODO: guard with when is_map(args)?
   def enqueue(repo, mod, args, opts \\ [priority: 100, timeout: -1, scheduled_at: nil]) do
     repo.insert(%__MODULE__{

--- a/test/backstage/job_test.exs
+++ b/test/backstage/job_test.exs
@@ -44,23 +44,6 @@ defmodule Backstage.JobTest do
     end
   end
 
-  describe "Backstage.Job.run/3" do
-    test "is successful" do
-      assert :ok == Job.run(FakeWorkingJob, :run, [%{}])
-    end
-
-    test "rescues any error raised" do
-      assert {:error, _reason} = Job.run(FakeFailingJob, :run, [%{}])
-    end
-
-    test "returns a formatted message with stacktrace if an error was raised" do
-      assert {:error, reason} = Job.run(FakeFailingJob, :run, [%{}])
-      assert reason =~ """
-        ** (UndefinedFunctionError) function :oops.exception/1 is undefined (module :oops is not available)
-        """
-    end
-  end
-
   describe "Backstage.Job.take/2" do
     setup [:enqueue_sample_jobs]
 


### PR DESCRIPTION
The `Backstage.Job` module is only concerned with the representation of a job and interfacing with the database so it doesn't make sense to keep this small bit here.

`Backstage.Consumer` is already handling much of the logic around running job and their underlying task so it feels natural to have that piece of logic there.
